### PR TITLE
Release 0.8.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.0
+current_version = 0.8.1-alpha
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<release>.*))?
 serialize = 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.1-alpha
+current_version = 0.8.1
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<release>.*))?
 serialize = 

--- a/bentley_ottmann/__init__.py
+++ b/bentley_ottmann/__init__.py
@@ -1,3 +1,3 @@
 """Searching line segments & polygon edges intersections."""
 
-__version__ = '0.8.1-alpha'
+__version__ = '0.8.1'

--- a/bentley_ottmann/__init__.py
+++ b/bentley_ottmann/__init__.py
@@ -1,3 +1,3 @@
-"""Bentley-Ottmann algorithm for searching line segments intersections."""
+"""Searching line segments & polygon edges intersections."""
 
 __version__ = '0.8.0'

--- a/bentley_ottmann/__init__.py
+++ b/bentley_ottmann/__init__.py
@@ -1,3 +1,3 @@
 """Searching line segments & polygon edges intersections."""
 
-__version__ = '0.8.0'
+__version__ = '0.8.1-alpha'

--- a/bentley_ottmann/core/event.py
+++ b/bentley_ottmann/core/event.py
@@ -53,6 +53,10 @@ class Event:
     def segment(self) -> Segment:
         return self.start, self.end
 
+    def set_both_relationships(self, relationship: SegmentsRelationship
+                               ) -> None:
+        self.relationship = self.complement.relationship = relationship
+
     def y_at(self, x: Coordinate) -> Coordinate:
         if self.is_vertical or self.is_horizontal:
             _, start_y = self.start

--- a/bentley_ottmann/core/event.py
+++ b/bentley_ottmann/core/event.py
@@ -30,10 +30,6 @@ class Event:
     __repr__ = recursive_repr()(generate_repr(__init__))
 
     @property
-    def is_intersection(self) -> bool:
-        return self.relationship is not SegmentsRelationship.NONE
-
-    @property
     def is_vertical(self) -> bool:
         start_x, _ = self.start
         end_x, _ = self.end

--- a/bentley_ottmann/core/event.py
+++ b/bentley_ottmann/core/event.py
@@ -62,12 +62,8 @@ class Event:
             _, start_y = self.start
             return start_y
         else:
-            start_x, start_y = self.start
-            if x == start_x:
-                return start_y
-            end_x, end_y = self.end
-            if x == end_x:
-                return end_y
+            _, start_y = self.start
+            _, end_y = self.end
             _, result = segments_intersection(self.segment,
                                               ((x, start_y), (x, end_y)))
             return result

--- a/bentley_ottmann/core/event.py
+++ b/bentley_ottmann/core/event.py
@@ -12,8 +12,8 @@ from .linear import (SegmentsRelationship,
 
 
 class Event:
-    __slots__ = ('is_left_endpoint', 'relationship',
-                 'start', 'complement', 'segments_ids')
+    __slots__ = ('is_left_endpoint', 'relationship', 'start', 'complement',
+                 'segments_ids')
 
     def __init__(self,
                  is_left_endpoint: bool,

--- a/bentley_ottmann/core/events_queue.py
+++ b/bentley_ottmann/core/events_queue.py
@@ -39,11 +39,7 @@ class EventsQueueKey:
         else:
             # same start,
             # both events are left endpoints or both are right endpoints
-            return ((event.segments_ids < other_event.segments_ids
-                     if event.is_intersection is other_event.is_intersection
-                     else event.is_intersection)
-                    if event.end == other_event.end
-                    else event.end < other_event.end)
+            return event.end < other_event.end
 
 
 EventsQueue = cast(Callable[..., PriorityQueue[Event]],

--- a/bentley_ottmann/core/planar.py
+++ b/bentley_ottmann/core/planar.py
@@ -33,13 +33,13 @@ def sweep(segments: Sequence[Segment],
     sweep_line = SweepLine()
     while events_queue:
         event = events_queue.pop()
-        point, same_point_events = event.start, [event]
+        point, same_start_events = event.start, [event]
         while events_queue and events_queue.peek().start == point:
-            same_point_events.append(events_queue.pop())
-        for event, other_event in to_pairs_combinations(same_point_events):
+            same_start_events.append(events_queue.pop())
+        for event, other_event in to_pairs_combinations(same_start_events):
             yield event, other_event
         sweep_line.move_to(point)
-        for event in same_point_events:
+        for event in same_start_events:
             if len(event.segments_ids) > 1:
                 yield event, event
 

--- a/bentley_ottmann/core/planar.py
+++ b/bentley_ottmann/core/planar.py
@@ -46,9 +46,6 @@ def sweep(segments: Sequence[Segment],
             yield event, other_event
         sweep_line.move_to(start)
         for event in same_start_events:
-            if len(event.segments_ids) > 1:
-                yield event, event
-
             if event.is_left_endpoint:
                 sweep_line.add(event)
                 above_event, below_event = (sweep_line.above(event),
@@ -68,6 +65,8 @@ def sweep(segments: Sequence[Segment],
                     if below_event is not None and above_event is not None:
                         detect_intersection(below_event, above_event,
                                             events_queue=events_queue)
+                if len(event.segments_ids) > 1:
+                    yield event, event
         prev_start, prev_same_start_events = start, same_start_events
 
 

--- a/bentley_ottmann/core/planar.py
+++ b/bentley_ottmann/core/planar.py
@@ -164,7 +164,7 @@ def detect_intersection(below_event: Event, event: Event,
             divide_segment(start_min, start_max.start, events_queue,
                            segments_ids)
     elif relationship is not SegmentsRelationship.NONE:
-        # segments intersect
+        # segments touch or cross
         yield below_event, event
 
         point = segments_intersection(below_segment, segment)

--- a/bentley_ottmann/core/planar.py
+++ b/bentley_ottmann/core/planar.py
@@ -1,4 +1,5 @@
 from typing import (Iterable,
+                    List,
                     Optional,
                     Sequence,
                     Tuple)
@@ -31,9 +32,14 @@ def sweep(segments: Sequence[Segment],
         segments = [to_rational_segment(segment) for segment in segments]
     events_queue = to_events_queue(segments)
     sweep_line = SweepLine()
+    prev_start = None
+    prev_same_start_events = []  # type: List[Event]
     while events_queue:
         event = events_queue.pop()
-        start, same_start_events = event.start, [event]
+        start = event.start
+        same_start_events = (prev_same_start_events + [event]
+                             if start == prev_start
+                             else [event])
         while events_queue and events_queue.peek().start == start:
             same_start_events.append(events_queue.pop())
         for event, other_event in to_pairs_combinations(same_start_events):
@@ -63,6 +69,7 @@ def sweep(segments: Sequence[Segment],
                         yield from detect_intersection(
                                 below_event, above_event,
                                 events_queue=events_queue)
+        prev_start, prev_same_start_events = start, same_start_events
 
 
 def to_events_queue(segments: Sequence[Segment]) -> EventsQueue:

--- a/bentley_ottmann/core/planar.py
+++ b/bentley_ottmann/core/planar.py
@@ -33,12 +33,12 @@ def sweep(segments: Sequence[Segment],
     sweep_line = SweepLine()
     while events_queue:
         event = events_queue.pop()
-        point, same_start_events = event.start, [event]
-        while events_queue and events_queue.peek().start == point:
+        start, same_start_events = event.start, [event]
+        while events_queue and events_queue.peek().start == start:
             same_start_events.append(events_queue.pop())
         for event, other_event in to_pairs_combinations(same_start_events):
             yield event, other_event
-        sweep_line.move_to(point)
+        sweep_line.move_to(start)
         for event in same_start_events:
             if len(event.segments_ids) > 1:
                 yield event, event

--- a/bentley_ottmann/core/planar.py
+++ b/bentley_ottmann/core/planar.py
@@ -54,11 +54,11 @@ def sweep(segments: Sequence[Segment],
                 above_event, below_event = (sweep_line.above(event),
                                             sweep_line.below(event))
                 if below_event is not None:
-                    yield from detect_intersection(below_event, event,
-                                                   events_queue=events_queue)
+                    detect_intersection(below_event, event,
+                                        events_queue=events_queue)
                 if above_event is not None:
-                    yield from detect_intersection(event, above_event,
-                                                   events_queue=events_queue)
+                    detect_intersection(event, above_event,
+                                        events_queue=events_queue)
             else:
                 event = event.complement
                 if event in sweep_line:
@@ -66,9 +66,8 @@ def sweep(segments: Sequence[Segment],
                                                 sweep_line.below(event))
                     sweep_line.remove(event)
                     if below_event is not None and above_event is not None:
-                        yield from detect_intersection(
-                                below_event, above_event,
-                                events_queue=events_queue)
+                        detect_intersection(below_event, above_event,
+                                            events_queue=events_queue)
         prev_start, prev_same_start_events = start, same_start_events
 
 
@@ -106,15 +105,12 @@ def to_events_queue(segments: Sequence[Segment]) -> EventsQueue:
 
 
 def detect_intersection(below_event: Event, event: Event,
-                        events_queue: EventsQueue
-                        ) -> Iterable[Tuple[Event, Event]]:
+                        events_queue: EventsQueue) -> None:
     below_segment, segment = below_event.segment, event.segment
     relationship = segments_relationship(below_segment, segment)
 
     if relationship is SegmentsRelationship.OVERLAP:
         # segments overlap
-        yield below_event, event
-
         starts_equal = event.start == below_event.start
         if starts_equal:
             start_min = start_max = None
@@ -173,8 +169,6 @@ def detect_intersection(below_event: Event, event: Event,
                            segments_ids)
     elif relationship is not SegmentsRelationship.NONE:
         # segments touch or cross
-        yield below_event, event
-
         point = segments_intersection(below_segment, segment)
         if point != below_event.start and point != below_event.end:
             divide_segment(below_event, point, events_queue)

--- a/bentley_ottmann/core/planar.py
+++ b/bentley_ottmann/core/planar.py
@@ -128,18 +128,19 @@ def detect_intersection(below_event: Event, event: Event,
         segments_ids = merge_ids(below_event.segments_ids,
                                  event.segments_ids)
         if starts_equal:
-            # both line segments are equal or share the left endpoint
             if ends_equal:
+                # segments are equal
                 below_event.segments_ids = event.segments_ids = segments_ids
                 event.set_both_relationships(relationship)
                 below_event.set_both_relationships(relationship)
             else:
+                # segments share the left endpoint
                 end_min.set_both_relationships(relationship)
                 end_max.complement.relationship = relationship
                 divide_segment(end_max.complement, end_min.start, events_queue,
                                segments_ids)
         elif ends_equal:
-            # the line segments share the right endpoint
+            # segments share the right endpoint
             start_max.set_both_relationships(relationship)
             start_min.complement.relationship = relationship
             divide_segment(start_min, start_max.start, events_queue,

--- a/bentley_ottmann/core/planar.py
+++ b/bentley_ottmann/core/planar.py
@@ -98,77 +98,89 @@ def to_events_queue(segments: Sequence[Segment]) -> EventsQueue:
     return events_queue
 
 
-def detect_intersection(first_event: Event, second_event: Event,
+def detect_intersection(below_event: Event, event: Event,
                         events_queue: EventsQueue
                         ) -> Iterable[Tuple[Event, Event]]:
-    first_segment, second_segment = first_event.segment, second_event.segment
-    relationship = segments_relationship(first_segment, second_segment)
+    below_segment, segment = below_event.segment, event.segment
+    relationship = segments_relationship(below_segment, segment)
 
-    if relationship is SegmentsRelationship.NONE:
-        return
-    elif relationship is SegmentsRelationship.OVERLAP:
+    if relationship is SegmentsRelationship.OVERLAP:
         # segments overlap
-        yield first_event, second_event
+        yield below_event, event
 
-        sorted_events = []
-        starts_equal = first_event.start == second_event.start
+        starts_equal = event.start == below_event.start
         if starts_equal:
-            sorted_events.append(None)
-        elif EventsQueueKey(first_event) > EventsQueueKey(second_event):
-            sorted_events.append(second_event)
-            sorted_events.append(first_event)
+            start_min = start_max = None
+        elif EventsQueueKey(event) < EventsQueueKey(below_event):
+            start_min, start_max = event, below_event
         else:
-            sorted_events.append(first_event)
-            sorted_events.append(second_event)
+            start_min, start_max = below_event, event
 
-        ends_equal = first_event.end == second_event.end
+        ends_equal = event.end == below_event.end
         if ends_equal:
-            sorted_events.append(None)
-        elif (EventsQueueKey(first_event.complement)
-              > EventsQueueKey(second_event.complement)):
-            sorted_events.append(second_event.complement)
-            sorted_events.append(first_event.complement)
+            end_min = end_max = None
+        elif (EventsQueueKey(event.complement)
+              < EventsQueueKey(below_event.complement)):
+            end_min, end_max = event.complement, below_event.complement
         else:
-            sorted_events.append(first_event.complement)
-            sorted_events.append(second_event.complement)
+            end_min, end_max = below_event.complement, event.complement
 
-        segments_ids = merge_ids(first_event.segments_ids,
-                                 second_event.segments_ids)
-        if starts_equal and ends_equal:
-            # both line segments are equal
-            first_event.relationship = second_event.relationship = relationship
-            first_event.segments_ids = second_event.segments_ids = segments_ids
-        elif starts_equal or ends_equal:
-            # line segments share endpoint
-            divide_segment(sorted_events[2].complement
-                           # line segments share the left endpoint
-                           if starts_equal
-                           # line segments share the right endpoint
-                           else sorted_events[0], sorted_events[1].start,
-                           relationship, events_queue, segments_ids)
+        segments_ids = merge_ids(below_event.segments_ids,
+                                 event.segments_ids)
+        if starts_equal:
+            # both line segments are equal or share the left endpoint
+            if ends_equal:
+                below_event.segments_ids = event.segments_ids = segments_ids
+                event.set_both_relationships(relationship)
+                below_event.set_both_relationships(relationship)
+            else:
+                end_min.set_both_relationships(relationship)
+                end_max.complement.relationship = relationship
+                divide_segment(end_max.complement, end_min.start, events_queue,
+                               segments_ids)
+        elif ends_equal:
+            # the line segments share the right endpoint
+            start_max.set_both_relationships(relationship)
+            start_min.complement.relationship = relationship
+            divide_segment(start_min, start_max.start, events_queue,
+                           segments_ids)
+        elif start_min is end_max.complement:
+            # one line segment includes the other one
+            start_max.set_both_relationships(relationship)
+            start_min_original_relationship = start_min.relationship
+            start_min.relationship = relationship
+            divide_segment(start_min, end_min.start, events_queue,
+                           segments_ids)
+            start_min.relationship = start_min_original_relationship
+            start_min.complement.relationship = relationship
+            divide_segment(start_min, start_max.start, events_queue,
+                           segments_ids)
         else:
-            divide_segment(sorted_events[0], sorted_events[1].start,
-                           relationship, events_queue, segments_ids)
-            divide_segment(sorted_events[0]
-                           # one line segment includes the other one
-                           if sorted_events[0] is sorted_events[3].complement
-                           # no line segment includes totally the other one
-                           else sorted_events[1], sorted_events[2].start,
-                           relationship, events_queue, segments_ids)
-    else:
+            # no line segment includes the other one
+            start_max.relationship = relationship
+            divide_segment(start_max, end_min.start, events_queue,
+                           segments_ids)
+            start_min.complement.relationship = relationship
+            divide_segment(start_min, start_max.start, events_queue,
+                           segments_ids)
+    elif relationship is not SegmentsRelationship.NONE:
         # segments intersect
-        yield first_event, second_event
+        yield below_event, event
 
-        point = segments_intersection(first_segment, second_segment)
-        if point != first_event.start and point != first_event.end:
-            divide_segment(first_event, point, relationship, events_queue)
-        if point != second_event.start and point != second_event.end:
-            divide_segment(second_event, point, relationship, events_queue)
+        point = segments_intersection(below_segment, segment)
+        if point != below_event.start and point != below_event.end:
+            divide_segment(below_event, point, events_queue)
+        if point != event.start and point != event.end:
+            divide_segment(event, point, events_queue)
+
+        event.set_both_relationships(max(event.relationship,
+                                         relationship))
+        below_event.set_both_relationships(max(below_event.relationship,
+                                               relationship))
 
 
 def divide_segment(event: Event,
                    break_point: Point,
-                   relationship: SegmentsRelationship,
                    events_queue: EventsQueue,
                    segments_ids: Optional[Sequence[int]] = None) -> None:
     if segments_ids is None:
@@ -176,16 +188,15 @@ def divide_segment(event: Event,
     else:
         event.segments_ids = segments_ids
     left_event = Event(is_left_endpoint=True,
-                       relationship=relationship,
+                       relationship=event.complement.relationship,
                        start=break_point,
                        complement=event.complement,
                        segments_ids=segments_ids)
     right_event = Event(is_left_endpoint=False,
-                        relationship=relationship,
+                        relationship=event.relationship,
                         start=break_point,
                         complement=event,
                         segments_ids=segments_ids)
-    event.relationship = relationship
     event.complement.complement, event.complement = left_event, right_event
     events_queue.push(left_event)
     events_queue.push(right_event)

--- a/bentley_ottmann/planar.py
+++ b/bentley_ottmann/planar.py
@@ -63,7 +63,7 @@ def edges_intersect(contour: Contour,
     if not _all_unique(contour):
         return True
 
-    edges = [(contour[index], contour[(index + 1) % len(contour)])
+    edges = [(contour[index - 1], contour[index])
              for index in range(len(contour))]
 
     def non_neighbours_intersect(edges_ids: Iterable[Tuple[int, int]],

--- a/docker-compose.cpython.yml
+++ b/docker-compose.cpython.yml
@@ -7,7 +7,7 @@ services:
       args:
         - PYTHON_IMAGE=${CPYTHON_IMAGE_NAME}
         - PYTHON_IMAGE_VERSION=${CPYTHON_IMAGE_VERSION}
-    image: lycantropos/bentley_ottmann-cpython:0.8.1-alpha
+    image: lycantropos/bentley_ottmann-cpython:0.8.1
     volumes:
       - ./bentley_ottmann/:/opt/bentley_ottmann/bentley_ottmann/
       - ./tests/:/opt/bentley_ottmann/tests/

--- a/docker-compose.cpython.yml
+++ b/docker-compose.cpython.yml
@@ -7,7 +7,7 @@ services:
       args:
         - PYTHON_IMAGE=${CPYTHON_IMAGE_NAME}
         - PYTHON_IMAGE_VERSION=${CPYTHON_IMAGE_VERSION}
-    image: lycantropos/bentley_ottmann-cpython:0.8.0
+    image: lycantropos/bentley_ottmann-cpython:0.8.1-alpha
     volumes:
       - ./bentley_ottmann/:/opt/bentley_ottmann/bentley_ottmann/
       - ./tests/:/opt/bentley_ottmann/tests/

--- a/docker-compose.pypy.yml
+++ b/docker-compose.pypy.yml
@@ -7,7 +7,7 @@ services:
       args:
         - PYTHON_IMAGE=${PYPY_IMAGE_NAME}
         - PYTHON_IMAGE_VERSION=${PYPY_IMAGE_VERSION}
-    image: lycantropos/bentley_ottmann-pypy:0.8.1-alpha
+    image: lycantropos/bentley_ottmann-pypy:0.8.1
     volumes:
       - ./bentley_ottmann/:/opt/bentley_ottmann/bentley_ottmann/
       - ./tests/:/opt/bentley_ottmann/tests/

--- a/docker-compose.pypy.yml
+++ b/docker-compose.pypy.yml
@@ -7,7 +7,7 @@ services:
       args:
         - PYTHON_IMAGE=${PYPY_IMAGE_NAME}
         - PYTHON_IMAGE_VERSION=${PYPY_IMAGE_VERSION}
-    image: lycantropos/bentley_ottmann-pypy:0.8.0
+    image: lycantropos/bentley_ottmann-pypy:0.8.1-alpha
     volumes:
       - ./bentley_ottmann/:/opt/bentley_ottmann/bentley_ottmann/
       - ./tests/:/opt/bentley_ottmann/tests/

--- a/tests/planar_tests/strategies.py
+++ b/tests/planar_tests/strategies.py
@@ -10,7 +10,8 @@ from bentley_ottmann.hints import (Point,
                                    Segment)
 from tests.strategies import (points_strategies,
                               segments_strategies)
-from tests.utils import Strategy
+from tests.utils import (Strategy,
+                         scale_segment)
 
 contours = points_strategies.flatmap(partial(strategies.lists,
                                              min_size=3))
@@ -40,6 +41,17 @@ def points_to_nets(points: Strategy[Point]) -> Strategy[List[Segment]]:
 nets = points_strategies.flatmap(points_to_nets)
 segments_lists = (segments_strategies.flatmap(strategies.lists)
                   | nets)
+
+
+def to_overlapped_segments(segments: List[Segment],
+                           scale: int) -> List[Segment]:
+    return segments + [scale_segment(segment,
+                                     scale=scale)
+                       for segment in segments]
+
+
+segments_lists |= strategies.builds(to_overlapped_segments, segments_lists,
+                                    strategies.integers(1, 100))
 empty_segments_lists = strategies.builds(list)
 non_empty_segments_lists = ((segments_strategies
                              .flatmap(partial(strategies.lists,


### PR DESCRIPTION
- Complete sweeping: fix bug for segments
```python
[((0, 0), (1, 0)),
 ((0, 0), (1, -1)),
 ((0, 0), (2, 0)),
 ((0, 0), (2, 1)),
 ((0, 0), (0, -1)),
 ((1, 0), (1, -1)),
 ((1, 0), (2, 0)),
 ((1, 0), (2, 1)),
 ((1, 0), (0, -1)),
 ((1, -1), (2, 0)),
 ((1, -1), (2, 1)),
 ((1, -1), (0, -1)),
 ((2, 0), (2, 1)),
 ((2, 0), (0, -1)),
 ((2, 1), (0, -1))]
```
(missing intersection in `(1.5, 0)`)